### PR TITLE
feat: make http port configurable

### DIFF
--- a/config/propeller.toml
+++ b/config/propeller.toml
@@ -30,3 +30,5 @@ DeviceAttributeHeaders = ["x-os", "x-os-version"]
     [Features.SampleFeature]
         Enabled = true
         RolloutPercentage = 100
+[Http]
+    Port = "8081"

--- a/internal/component/api_server_component.go
+++ b/internal/component/api_server_component.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/CRED-CLUB/propeller/internal/component/apiserver"
@@ -19,10 +20,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	grpctrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc"
-)
-
-const (
-	httpAddr = ":8081"
 )
 
 // NewAPIServer returns a component instance
@@ -104,7 +101,7 @@ func (web *APIServer) Start(ctx context.Context) error {
 		err := s.Run(gctx)
 		return err
 	})
-	httpSrv := &http.Server{Addr: httpAddr}
+	httpSrv := &http.Server{Addr: fmt.Sprintf(":%s", (web.config.HTTP.Port))}
 	ws := apiserver.WebSocketServerWrapper{PushServer: pushGrpcService, Ctx: cancelCtx, CancelFunc: cancelFunc}
 	grp.Go(func() error {
 		m := http.NewServeMux()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"github.com/CRED-CLUB/propeller/internal/broker"
 	"github.com/CRED-CLUB/propeller/internal/feature"
 	"github.com/CRED-CLUB/propeller/internal/grpcserver"
+	"github.com/CRED-CLUB/propeller/internal/httpserver"
 	"github.com/CRED-CLUB/propeller/pkg/logger"
 )
 
@@ -20,4 +21,5 @@ type Config struct {
 	ClientHeader           string
 	DeviceHeader           string
 	EnableDeviceSupport    bool
+	HTTP                   httpserver.HTTPConfig
 }

--- a/internal/httpserver/config.go
+++ b/internal/httpserver/config.go
@@ -1,0 +1,6 @@
+package httpserver
+
+// HTTPConfig holds config for HTTP server
+type HTTPConfig struct {
+	Port string
+}


### PR DESCRIPTION
- Make HTTP port configurable, which is used to expose Prometheus metrics and WebSocket