### PR TITLE
Adding debug APIs using pprof

### DIFF
--- a/config/propeller.toml
+++ b/config/propeller.toml
@@ -5,6 +5,7 @@ ClientHeader = "x-user-id"
 EnableDeviceSupport = true
 DeviceHeader = "x-device-id"
 DeviceAttributeHeaders = ["x-os", "x-os-version"]
+EnableProfilingHandlers = false
 
 [broker]
     broker = "redis" # broker = "nats" or "redis"

--- a/internal/component/api_server_component.go
+++ b/internal/component/api_server_component.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 
 	"github.com/CRED-CLUB/propeller/internal/component/apiserver"
 	"github.com/CRED-CLUB/propeller/internal/config"
@@ -117,6 +118,10 @@ func (web *APIServer) Start(ctx context.Context) error {
 			"/ws/connect",
 			ws.WebSocketConnect,
 		)
+		if web.config.EnableProfilingHandlers {
+			// debug handlers for profiling
+			m.Handle("/debug/", http.DefaultServeMux)
+		}
 
 		httpSrv.Handler = m
 		return httpSrv.ListenAndServe()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,16 +10,17 @@ import (
 
 // Config stores application config
 type Config struct {
-	ServiceName            string
-	SendTestPayload        bool
-	SendTestPayloadToTopic bool
-	Broker                 broker.Config
-	Grpc                   grpcserver.Config
-	Features               feature.Config
-	Logger                 logger.Config
-	DeviceAttributeHeaders []string
-	ClientHeader           string
-	DeviceHeader           string
-	EnableDeviceSupport    bool
-	HTTP                   httpserver.HTTPConfig
+	ServiceName             string
+	SendTestPayload         bool
+	SendTestPayloadToTopic  bool
+	Broker                  broker.Config
+	Grpc                    grpcserver.Config
+	Features                feature.Config
+	Logger                  logger.Config
+	DeviceAttributeHeaders  []string
+	ClientHeader            string
+	DeviceHeader            string
+	EnableDeviceSupport     bool
+	HTTP                    httpserver.HTTPConfig
+	EnableProfilingHandlers bool
 }


### PR DESCRIPTION
Changes:
- Added a REST server that serves debug routes.
- Created a new package for having all the constants.

Testing:
Tested the pprof using rest server and was able to visualise with Graphviz.

Sample command:
```
─╯ go tool pprof http://localhost:8081/debug/pprof/goroutine      <<< command to get goroutines

                                                 
  Fetching profile over HTTP from http://localhost:9001/debug/pprof/goroutine
  Saved profile in /Users/avish/pprof/pprof.propeller.goroutine.003.pb.gz
  File: propeller
  Type: goroutine
  Time: Dec 22, 2024 at 10:23am (IST)
  Entering interactive mode (type "help" for commands, "o" for options)
  (pprof) 
```
