### PR TITLE
fix: coverage badge input file name

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Go Coverage Badge  # Pass the `coverage.out` output to this action
         uses: tj-actions/coverage-badge-go@v2
         with:
-          filename: coverage.out
+          filename: coverage-summary.out
           target: Readme.md
 
       - name: Check for README Changes


### PR DESCRIPTION
- The earlier [PR](https://github.com/CRED-CLUB/propeller/pull/60) broke the coverage badge.
- This PR fixes that.